### PR TITLE
fix: Initialize mainindex to prevent random value matching in sproto_…

### DIFF
--- a/src/pysproto/python_sproto.c
+++ b/src/pysproto/python_sproto.c
@@ -400,7 +400,7 @@ py_sproto_decode(PyObject *pymodule, PyObject *args) {
     }
     self.table = PyDict_New();
     self.map_key = NULL;
-    self.mainindex = 1;
+    self.mainindex = -1;
     //printf("msg len:%d\n", sz);
     sprototype = PyCapsule_GetPointer(st_capsule, NULL);
     int r = sproto_decode(sprototype, buffer, sz, decode, &self);

--- a/src/pysproto/python_sproto.c
+++ b/src/pysproto/python_sproto.c
@@ -270,6 +270,7 @@ decode(const struct sproto_arg *args) {
 		struct decode_ud sub;
 		int r;
         sub.table = PyDict_New();
+        sub.map_key = NULL;
         if (args->mainindex >= 0) {
             //This struct will set into a map
             sub.mainindex = args->mainindex;
@@ -398,7 +399,8 @@ py_sproto_decode(PyObject *pymodule, PyObject *args) {
         return NULL;
     }
     self.table = PyDict_New();
-    self.mainindex = 1;  // Initialize to prevent random value matching
+    self.map_key = NULL;
+    self.mainindex = 1;
     //printf("msg len:%d\n", sz);
     sprototype = PyCapsule_GetPointer(st_capsule, NULL);
     int r = sproto_decode(sprototype, buffer, sz, decode, &self);

--- a/src/pysproto/python_sproto.c
+++ b/src/pysproto/python_sproto.c
@@ -398,6 +398,7 @@ py_sproto_decode(PyObject *pymodule, PyObject *args) {
         return NULL;
     }
     self.table = PyDict_New();
+    self.mainindex = 1;  // Initialize to prevent random value matching
     //printf("msg len:%d\n", sz);
     sprototype = PyCapsule_GetPointer(st_capsule, NULL);
     int r = sproto_decode(sprototype, buffer, sz, decode, &self);


### PR DESCRIPTION
fix: Initialize mainindex to prevent random value matching in sproto_decode

Initialize self.mainindex to -1 in py_sproto_decode function to prevent
random stack value from matching tagid, which causes occasional parsing
failures in map structures.

The mainindex member of decode_ud struct was uninitialized, containing
random stack values. If this random value happened to match a field's
tagid, it would incorrectly set map_key and cause parsing failures.

By initializing mainindex to -1, we ensure it won't match any valid
tagid (which are typically positive integers), preventing the issue.

Fixes #40